### PR TITLE
Updated picker to use $expand

### DIFF
--- a/src/com/microsoft/onenote/pickerlib/ApiAsyncResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiAsyncResponse.java
@@ -6,5 +6,5 @@
 package com.microsoft.onenote.pickerlib;
 
 interface ApiAsyncResponse {
-    void onApiResponse(ApiResponse[] responses, Exception error);
+    void onApiResponse(ApiNotebookResponse[] responses, Exception error);
 }

--- a/src/com/microsoft/onenote/pickerlib/ApiController.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiController.java
@@ -5,89 +5,16 @@
 //----------------------------------------------------------------------------
 package com.microsoft.onenote.pickerlib;
 
-import java.util.LinkedList;
-
 abstract class ApiController implements ApiAsyncResponse {
-    final LinkedList<ApiRequestAsyncTask> mQueuedTasks = new LinkedList<ApiRequestAsyncTask>();
     private final String mAccessToken;
-    ApiRequestAsyncTask mTopPriorityTask = null;
-
 
     public ApiController(String accessToken) {
         mAccessToken = accessToken;
     }
 
-    @Override
-    public synchronized void onApiResponse(ApiResponse[] responses, Exception error) {
-        if (error != null) {
-            onApiError(error);
-            return;
-        }
-        handleApiResponse(responses);
-        executeNext();
-    }
-
-    protected synchronized void executeNext() {
-        if (mTopPriorityTask == null) {
-            ApiRequestAsyncTask task = mQueuedTasks.poll();
-            if (task != null) {
-                task.execute();
-            }
-        } else {
-            mTopPriorityTask.execute();
-            mTopPriorityTask = null;
-        }
-    }
-
-    private void handleApiResponse(ApiResponse[] responses) {
-        for (ApiResponse response : responses) {
-            ApiRequestAsyncTask task = buildApiRequestTask(response);
-            if (task != null) {
-                mQueuedTasks.add(task);
-            }
-        }
-    }
-
-    private ApiRequestAsyncTask buildApiRequestTask(ApiResponse resultData) {
-        ApiRequestEndpoint primaryEndpoint = null;
-        if (resultData instanceof ApiNotebookResponse) {
-            primaryEndpoint = ApiRequestEndpoint.NOTEBOOKS;
-        } else if (resultData instanceof ApiSectionGroupResponse) {
-            primaryEndpoint = ApiRequestEndpoint.SECTION_GROUPS;
-        }
-        if (primaryEndpoint != null) {
-            ApiRequestAsyncTask task = new ApiRequestAsyncTask(mAccessToken,
-                    new ApiRequest(primaryEndpoint, resultData.getId(),
-                            ApiRequestEndpoint.SECTIONS),
-                    new ApiRequest(primaryEndpoint, resultData.getId(),
-                            ApiRequestEndpoint.SECTION_GROUPS)
-            );
-            task.addDelegate(this);
-            task.addDelegate(getApiResponseDelegate(resultData));
-            return task;
-        } else {
-            return null;
-        }
-    }
-
-    public void begin(ApiAsyncResponse initialDelegate) {
-        ApiRequestAsyncTask initialTask = new ApiRequestAsyncTask(mAccessToken,
-                new ApiRequest(ApiRequestEndpoint.NOTEBOOKS));
+    public void begin() {
+        ApiRequestAsyncTask initialTask = new ApiRequestAsyncTask(mAccessToken, new ApiRequest(ApiRequestEndpoint.EXPAND));
         initialTask.addDelegate(this);
-        initialTask.addDelegate(initialDelegate);
-
-        mQueuedTasks.add(initialTask);
-        executeNext();
+        initialTask.execute();
     }
-
-    public void prioritize(ApiResponse resultData) {
-        mTopPriorityTask = buildApiRequestTask(resultData);
-        // Remove prioritized task from the queue
-        mQueuedTasks.remove(mTopPriorityTask);
-    }
-
-    protected abstract ApiAsyncResponse getApiResponseDelegate(ApiResponse response);
-
-    protected abstract void onApiError(Exception error);
-
 }

--- a/src/com/microsoft/onenote/pickerlib/ApiNotebookResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiNotebookResponse.java
@@ -5,12 +5,22 @@
 //----------------------------------------------------------------------------
 package com.microsoft.onenote.pickerlib;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 class ApiNotebookResponse extends ApiSectionGroupResponse {
     protected boolean isDefault;
     protected String createdBy;
     protected String userRole;
     protected String ownerName;
 
+    public ApiNotebookResponse(JSONObject object) throws JSONException{
+        super(object);
+    	setIsDefault(object.optBoolean("isDefault"));
+        setUserRole(object.optString("userRole"));
+        setOwnerName(object.optString("ownerName"));
+    }
+    
     public boolean getIsDefault() {
         return isDefault;
     }

--- a/src/com/microsoft/onenote/pickerlib/ApiRequest.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiRequest.java
@@ -6,43 +6,13 @@
 package com.microsoft.onenote.pickerlib;
 
 class ApiRequest {
-    ApiRequestEndpoint primaryEndpoint = null;
-    String resourceId = null;
-    ApiRequestEndpoint secondaryEndpoint = null;
+    ApiRequestEndpoint endpoint = null;
 
     public ApiRequest(ApiRequestEndpoint endpoint) {
-        this.primaryEndpoint = endpoint;
-    }
-
-    public ApiRequest(ApiRequestEndpoint primaryEndpoint, String resourceId, ApiRequestEndpoint secondEndpoint) {
-        this.primaryEndpoint = primaryEndpoint;
-        this.resourceId = resourceId;
-        this.secondaryEndpoint = secondEndpoint;
-    }
-
-    public ApiRequestEndpoint getPrimaryEndpoint() {
-        return primaryEndpoint;
-    }
-
-    public String getResourceId() {
-        return resourceId;
-    }
-
-    public ApiRequestEndpoint getSecondaryEndpoint() {
-        return secondaryEndpoint;
-    }
-
-    public boolean hasResourceId() {
-        return resourceId != null;
-    }
-
-    public boolean hasSecondaryEndpoint() {
-        return secondaryEndpoint != null;
+        this.endpoint = endpoint;
     }
 
     public String getEndpointURL() {
-        return primaryEndpoint.toString() + "/"
-                + (hasResourceId() ? resourceId + "/" : "")
-                + (hasSecondaryEndpoint() ? secondaryEndpoint.toString() + "/" : "");
+        return endpoint.toString();
     }
 }

--- a/src/com/microsoft/onenote/pickerlib/ApiRequestEndpoint.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiRequestEndpoint.java
@@ -6,7 +6,7 @@
 package com.microsoft.onenote.pickerlib;
 
 enum ApiRequestEndpoint {
-    NOTEBOOKS("Notebooks"), SECTION_GROUPS("SectionGroups"), SECTIONS("Sections");
+    EXPAND("Notebooks?$expand=sections,sectionGroups($expand=sections,sectionGroups($expand=sections;$levels=max))");
 
     private final String string;
 
@@ -17,5 +17,4 @@ enum ApiRequestEndpoint {
     public String toString() {
         return string;
     }
-
 }

--- a/src/com/microsoft/onenote/pickerlib/ApiResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiResponse.java
@@ -5,10 +5,12 @@
 //----------------------------------------------------------------------------
 package com.microsoft.onenote.pickerlib;
 
-import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 class ApiResponse {
     protected String id;
@@ -17,6 +19,15 @@ class ApiResponse {
     protected Date modifiedTime;
     protected String lastModifiedBy;
 
+    public ApiResponse(JSONObject object) throws JSONException{
+        // Apply properties common to all response types
+        setId(object.getString("id"));
+        setName(object.getString("name"));
+        setCreatedTime(object.optString("createdTime"));
+        setModifiedTime(object.optString("lastModifiedTime"));
+        setLastModifiedBy(object.optString("lastModifiedBy"));
+    }
+    
     public String getId() {
         return id;
     }

--- a/src/com/microsoft/onenote/pickerlib/ApiSectionGroupResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiSectionGroupResponse.java
@@ -6,11 +6,22 @@
 package com.microsoft.onenote.pickerlib;
 
 import java.net.URL;
+import java.util.List;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 class ApiSectionGroupResponse extends ApiResponse {
     protected URL sectionsUrl;
     protected URL sectionGroupsUrl;
 
+    public ApiSectionGroupResponse(JSONObject object) throws JSONException{
+    	super(object);
+    }
+    
+    public List<ApiSectionResponse> sections;
+    public List<ApiSectionGroupResponse> sectionGroups;
+    
     public URL getSectionsUrl() {
         return sectionsUrl;
     }

--- a/src/com/microsoft/onenote/pickerlib/ApiSectionResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiSectionResponse.java
@@ -5,12 +5,27 @@
 //----------------------------------------------------------------------------
 package com.microsoft.onenote.pickerlib;
 
+import java.net.MalformedURLException;
 import java.net.URL;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 class ApiSectionResponse extends ApiResponse {
     private boolean isDefault;
     private URL pagesUrl;
 
+    public ApiSectionResponse(JSONObject object) throws JSONException, MalformedURLException{
+    	super(object);
+        JSONObject links = object.optJSONObject("links");
+        setIsDefault(object.optBoolean("isDefault"));
+        if (links != null) {
+            setPagesUrl(new URL(links.getJSONObject("pagesUrl").getString("href")));
+        } else {
+            setPagesUrl(new URL(object.getString("pagesUrl")));
+        }
+    }
+    
     public boolean getIsDefault() {
         return isDefault;
     }


### PR DESCRIPTION
This PR contains changes to modify the Android picker to use $expand. As explained in this blog post

http://blogs.msdn.com/b/onenotedev/archive/2014/12/16/beta-get-onenote-entities-in-one-roundtrip-using-expand.aspx

Expand improves the picker's performance by reducing the number of API calls it needs to make.
