### PR TITLE
Fix a potential crash in ApiSectionResponse

### DIFF
--- a/src/com/microsoft/onenote/pickerlib/ApiSectionResponse.java
+++ b/src/com/microsoft/onenote/pickerlib/ApiSectionResponse.java
@@ -16,13 +16,14 @@ class ApiSectionResponse extends ApiResponse {
     private URL pagesUrl;
 
     public ApiSectionResponse(JSONObject object) throws JSONException, MalformedURLException{
-    	super(object);
-        JSONObject links = object.optJSONObject("links");
-        setIsDefault(object.optBoolean("isDefault"));
-        if (links != null) {
-            setPagesUrl(new URL(links.getJSONObject("pagesUrl").getString("href")));
-        } else {
-            setPagesUrl(new URL(object.getString("pagesUrl")));
+        super(object);
+
+        if (object != null) {
+            setIsDefault(object.optBoolean("isDefault"));
+
+            if (object.has("pagesUrl")) {
+                this.setPagesUrl(new URL(object.getString("pagesUrl")));
+            }
         }
     }
     


### PR DESCRIPTION
There is a case where a notebook can have no sections in it. Under these
conditions the existing code would crash, as generating a new URL with a
null string throws.  So, checking to ensure that the property exists
before generating the ULR fixes the problem.

Also, there was some incorrect logic around the "links" node. The schema
does not allow for the pagesUrl property, so the code as written will
never work.  Cleaning out that logic fixes things up.